### PR TITLE
Merge mw-next into develop

### DIFF
--- a/src/components/tw-cloud-variable-badge/cloud-variable-badge.jsx
+++ b/src/components/tw-cloud-variable-badge/cloud-variable-badge.jsx
@@ -72,7 +72,7 @@ const CloudVariableBadge = props => {
                     />
                     {hosts.map(i => (
                         <CloudServerButton
-                            key={i.ws}
+                            key={i.cloudHost}
                             name={i.name}
                             cloudHost={i.cloudHost}
                             selected={props.cloudHost === i.cloudHost}

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -1139,6 +1139,8 @@ class Blocks extends React.Component {
                 const staticBlocksJson = [];
                 const dynamicBlocksInfo = [];
                 blockInfoArray.forEach(blockInfo => {
+                    // Patching uses native extendable Scratch Blocks definitions.
+                    if (categoryInfo.id === 'patching') return;
                     if (blockInfo.info && blockInfo.info.isDynamic) {
                         dynamicBlocksInfo.push(blockInfo);
                     } else if (blockInfo.json) {

--- a/src/containers/monitor.jsx
+++ b/src/containers/monitor.jsx
@@ -265,15 +265,9 @@ Monitor.propTypes = {
     targetId: PropTypes.string,
     theme: PropTypes.instanceOf(Theme),
     toolboxXML: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    value: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-        PropTypes.object,
-        PropTypes.arrayOf(PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.number
-        ]))
-    ]), // eslint-disable-line react/no-unused-prop-types
+    // Extension reporters and injected projects can return any JavaScript value;
+    // monitorAdapter normalizes it before rendering.
+    value: PropTypes.any, // eslint-disable-line react/no-unused-prop-types, react/forbid-prop-types
     vm: PropTypes.instanceOf(VM),
     width: PropTypes.number,
     x: PropTypes.number,

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -80,6 +80,15 @@ export default [
         featured: true
     },
     {
+        name: 'Patching',
+        extensionId: 'patching',
+        iconURL: twIcon,
+        description: 'Inject JavaScript into compiled projects.',
+        incompatibleWithScratch: true,
+        tags: ['tw'],
+        featured: true
+    },
+    {
         name: (
             <FormattedMessage
                 defaultMessage="Custom Extension"

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -197,7 +197,7 @@ const xmlEscape = function (unsafe) {
     });
 };
 
-const looks = function (isInitialSetup, isStage, targetId, costumeName, backdropName, colors) {
+const looks = function (isInitialSetup, isStage, targetId, costumeName, backdropName, colors, vanilla) {
     const hello = translate('LOOKS_HELLO', 'Hello!');
     const hmm = translate('LOOKS_HMM', 'Hmm...');
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
@@ -329,7 +329,7 @@ const looks = function (isInitialSetup, isStage, targetId, costumeName, backdrop
             <block id="${targetId}_costumenumbername" type="looks_costumenumbername"/>
             <block id="backdropnumbername" type="looks_backdropnumbername"/>
             <block id="${targetId}_size" type="looks_size"/>
-            <block id="${targetId}_costumes" type="looks_costumes"/>
+            ${vanilla ? '' : `<block id="${targetId}_costumes" type="looks_costumes"/>`}
         `}
         ${categorySeparator}
     </category>
@@ -522,7 +522,7 @@ const control = function (isInitialSetup, isStage, targetId, colors, vanilla) {
     `;
 };
 
-const sensing = function (isInitialSetup, isStage, targetId, colors) {
+const sensing = function (isInitialSetup, isStage, targetId, colors, vanilla) {
     const name = translate('SENSING_ASK_TEXT', 'What\'s your name?');
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
@@ -576,6 +576,10 @@ const sensing = function (isInitialSetup, isStage, targetId, colors) {
         <block type="sensing_mousedown"/>
         <block type="sensing_mousex"/>
         <block type="sensing_mousey"/>
+        ${vanilla ? '' : `
+            <block type="sensing_stagewidth"/>
+            <block type="sensing_stageheight"/>
+        `}
         ${isStage ? '' : `
             ${blockSeparator}
             '<block type="sensing_setdragmode" id="sensing_setdragmode"></block>'+
@@ -603,7 +607,7 @@ const sensing = function (isInitialSetup, isStage, targetId, colors) {
     `;
 };
 
-const operators = function (isInitialSetup, isStage, targetId, colors) {
+const operators = function (isInitialSetup, isStage, targetId, colors, vanilla) {
     // Note: the category's secondaryColour matches up with the blocks' tertiary color, both used for border color.
     return `
     <category
@@ -659,6 +663,21 @@ const operators = function (isInitialSetup, isStage, targetId, colors) {
                 </shadow>
             </value>
         </block>
+        ${vanilla ? '' : `
+        <block type="operator_min">
+            <value name="NUM1"><shadow type="math_number"><field name="NUM"/></shadow></value>
+            <value name="NUM2"><shadow type="math_number"><field name="NUM"/></shadow></value>
+        </block>
+        <block type="operator_max">
+            <value name="NUM1"><shadow type="math_number"><field name="NUM"/></shadow></value>
+            <value name="NUM2"><shadow type="math_number"><field name="NUM"/></shadow></value>
+        </block>
+        <block type="operator_clamp">
+            <value name="NUM"><shadow type="math_number"><field name="NUM">50</field></shadow></value>
+            <value name="MIN"><shadow type="math_number"><field name="NUM">0</field></shadow></value>
+            <value name="MAX"><shadow type="math_number"><field name="NUM">100</field></shadow></value>
+        </block>
+        `}
         ${blockSeparator}
         <block type="operator_random">
             <value name="FROM">
@@ -955,15 +974,16 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     };
     const motionXML = moveCategory('motion') || motion(isInitialSetup, isStage, targetId, colors.motion, vanilla);
     const looksXML = moveCategory('looks') ||
-        looks(isInitialSetup, isStage, targetId, costumeName, backdropName, colors.looks);
+        looks(isInitialSetup, isStage, targetId, costumeName, backdropName, colors.looks, vanilla);
     const soundXML = moveCategory('sound') || sound(isInitialSetup, isStage, targetId, soundName, colors.sounds);
     const assetsXML = moveCategory('assets') || assets(isInitialSetup, isStage, targetId, assetName, colors.assets);
     const eventsXML = moveCategory('event') || events(isInitialSetup, isStage, targetId, colors.event);
     const controlXML = moveCategory('control') || control(isInitialSetup, isStage, targetId, colors.control, vanilla);
-    const sensingXML = moveCategory('sensing') || sensing(isInitialSetup, isStage, targetId, colors.sensing);
+    const sensingXML = moveCategory('sensing') || sensing(isInitialSetup, isStage, targetId, colors.sensing, vanilla);
     const operatorsXML = moveCategory('operators') ||
-        operators(isInitialSetup, isStage, targetId, colors.operators);
+        operators(isInitialSetup, isStage, targetId, colors.operators, vanilla);
     const stringsXML = strings(isInitialSetup, isStage, targetId, colors.strings, vanilla);
+    const patchingXML = moveCategory('patching');
     const variablesXML = moveCategory('data') || variables(isInitialSetup, isStage, targetId, colors.data);
     const myBlocksXML = moveCategory('procedures') || myBlocks(isInitialSetup, isStage, targetId, colors.more);
 
@@ -985,6 +1005,7 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
         sensingXML, gap,
         operatorsXML, gap,
         stringsXML, gap,
+        ...(patchingXML ? [patchingXML, gap] : []),
         variablesXML, gap,
         myBlocksXML
     ];

--- a/src/lib/utils/monitor-adapter.js
+++ b/src/lib/utils/monitor-adapter.js
@@ -38,11 +38,11 @@ export default function ({id, spriteName, opcode, params, value, vm}) {
         value = value.slice();
         for (let i = 0; i < value.length; i++) {
             const item = value[i];
-            if (typeof item !== 'string' || typeof item !== 'number') {
+            if (typeof item !== 'string' && typeof item !== 'number') {
                 value[i] = safeStringify(item);
             }
         }
-    } else if (typeof value !== 'string' || typeof value !== 'number') {
+    } else if (typeof value !== 'string' && typeof value !== 'number') {
         value = safeStringify(value);
     }
 

--- a/test/unit/util/monitor-adapter.test.js
+++ b/test/unit/util/monitor-adapter.test.js
@@ -1,0 +1,16 @@
+import monitorAdapter from '../../../src/lib/utils/monitor-adapter';
+
+describe('monitor adapter', () => {
+    test('normalizes arbitrary list values without changing strings and numbers', () => {
+        const value = ['message', 2, true, {text: 'hello'}];
+        const result = monitorAdapter({
+            id: 'list',
+            opcode: 'data_listcontents',
+            params: {},
+            value
+        });
+
+        expect(result.value).toEqual(['message', 2, 'true', '{"text":"hello"}']);
+        expect(value).toEqual(['message', 2, true, {text: 'hello'}]);
+    });
+});


### PR DESCRIPTION
Brings mw-next into develop:

- Add opt-in Patching toolbox category
- Fix monitor values and cloud server keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MistWarp/codesmith/scratch-gui/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786644508&installation_id=145714314&pr_number=8&repository=MistWarp%2Fscratch-gui&return_to=https%3A%2F%2Fgithub.com%2FMistWarp%2Fscratch-gui%2Fpull%2F8&signature=45c84bf2b52a6d216ab2cd1d2d5b5555215d8e00fa8ead26b383f82991e3dc48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->